### PR TITLE
Add IWP pattern generator scripts and documentation

### DIFF
--- a/firmware/Python/iwp-cube.py
+++ b/firmware/Python/iwp-cube.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+
+# Rotating 3D wireframe cube via IWP
+# Usage: python iwp-cube.py --ip 192.168.0.209
+
+import argparse
+import math
+import socket
+import struct
+import time
+
+IW_TYPE_0 = 0x00
+IW_TYPE_1 = 0x01
+IW_TYPE_3 = 0x03
+
+UDP_PORT = 7200
+
+CENTER = 0x8000
+SCALE = 0x4000
+POINTS_PER_EDGE = 10
+BLANK_DWELL = 3
+
+# Unit cube vertices centered at origin
+VERTICES = [
+    (-1, -1, -1),
+    ( 1, -1, -1),
+    ( 1,  1, -1),
+    (-1,  1, -1),
+    (-1, -1,  1),
+    ( 1, -1,  1),
+    ( 1,  1,  1),
+    (-1,  1,  1),
+]
+
+# Edges as vertex index pairs - ordered to minimize blanking moves
+# Draw bottom face, then top face, then verticals
+EDGES = [
+    (0, 1), (1, 2), (2, 3), (3, 0),  # back face
+    (4, 5), (5, 6), (6, 7), (7, 4),  # front face
+    (0, 4), (1, 5), (2, 6), (3, 7),  # connecting edges
+]
+
+# Optimal draw order: trace continuous paths where possible
+# Back face loop -> jump to front face loop -> verticals
+DRAW_ORDER = [
+    (0, 1), (1, 2), (2, 3), (3, 0),  # back face (continuous)
+    (0, 4),                            # vertical (continuous from v0)
+    (4, 5), (5, 6), (6, 7), (7, 4),  # front face (continuous)
+    (5, 1),                            # vertical back (continuous from v5)
+    (2, 6),                            # jump to v2, vertical
+    (3, 7),                            # jump to v3, vertical
+]
+
+
+def rotate_x(v, a):
+    x, y, z = v
+    c, s = math.cos(a), math.sin(a)
+    return (x, y * c - z * s, y * s + z * c)
+
+
+def rotate_y(v, a):
+    x, y, z = v
+    c, s = math.cos(a), math.sin(a)
+    return (x * c + z * s, y, -x * s + z * c)
+
+
+def rotate_z(v, a):
+    x, y, z = v
+    c, s = math.cos(a), math.sin(a)
+    return (x * c - y * s, x * s + y * c, z)
+
+
+def clamp16(v):
+    return max(0, min(0xFFFF, v))
+
+
+def project(v, fov=2.5):
+    """Perspective projection."""
+    x, y, z = v
+    d = fov / (fov + z)
+    return (clamp16(int(CENTER + x * SCALE * d)), clamp16(int(CENTER + y * SCALE * d)))
+
+
+def interpolate(x0, y0, x1, y1, steps):
+    pts = []
+    for i in range(steps + 1):
+        t = i / steps
+        pts.append((int(x0 + (x1 - x0) * t), int(y0 + (y1 - y0) * t)))
+    return pts
+
+
+def build_cube_frame(ax, ay, az, r, g, b):
+    """Build a wireframe cube frame with rotation angles ax, ay, az."""
+    # Transform vertices
+    projected = []
+    for v in VERTICES:
+        v = rotate_x(v, ax)
+        v = rotate_y(v, ay)
+        v = rotate_z(v, az)
+        projected.append(project(v))
+
+    frame = []
+    prev_end = None
+
+    for (i0, i1) in DRAW_ORDER:
+        x0, y0 = projected[i0]
+        x1, y1 = projected[i1]
+
+        # If start of this edge != end of last edge, blank move
+        if prev_end is None or prev_end != (x0, y0):
+            # Dwell blank at current position
+            if prev_end:
+                for _ in range(BLANK_DWELL):
+                    frame.append((*prev_end, 0, 0, 0))
+            # Blank move to start of new edge
+            for _ in range(BLANK_DWELL):
+                frame.append((x0, y0, 0, 0, 0))
+
+        # Draw edge
+        seg = interpolate(x0, y0, x1, y1, POINTS_PER_EDGE)
+        for sx, sy in seg:
+            frame.append((sx, sy, r, g, b))
+
+        prev_end = (x1, y1)
+
+    # Final dwell
+    if prev_end:
+        for _ in range(BLANK_DWELL):
+            frame.append((*prev_end, 0, 0, 0))
+
+    return frame
+
+
+POINT_SIZE = 11  # 1 byte type + 5 * 2 bytes
+MAX_PACKET = 1023
+MAX_POINTS_PER_PACKET = MAX_PACKET // POINT_SIZE
+
+
+def pack_frame(frame):
+    """Pack frame into chunked packets that fit within UDP MTU."""
+    packets = []
+    for i in range(0, len(frame), MAX_POINTS_PER_PACKET):
+        chunk = frame[i:i + MAX_POINTS_PER_PACKET]
+        packets.append(b''.join(
+            struct.pack('>BHHHHH', IW_TYPE_3, x, y, r, g, b)
+            for x, y, r, g, b in chunk
+        ))
+    return packets
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Rotating 3D cube via IWP")
+    ap.add_argument("--ip", required=True, help="Projector IP address")
+    ap.add_argument("--scan", type=int, default=25000, help="Scan rate Hz (default 25000)")
+    ap.add_argument("--rpm", type=float, default=20, help="Rotation speed RPM (default 20)")
+    ap.add_argument("--color", default="00ff40", help="Hex color (default 00ff40)")
+    args = ap.parse_args()
+
+    c = args.color.lstrip('#')
+    r = int(c[0:2], 16) << 8 | int(c[0:2], 16)
+    g = int(c[2:4], 16) << 8 | int(c[2:4], 16)
+    b = int(c[4:6], 16) << 8 | int(c[4:6], 16)
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    target = (args.ip, UDP_PORT)
+
+    scan_period = max(1, int(1_000_000 / args.scan))
+    sock.sendto(struct.pack('>BI', IW_TYPE_1, scan_period), target)
+    time.sleep(0.01)
+
+    rads_per_sec = args.rpm * 2 * math.pi / 60
+
+    # Calculate how many times to repeat each frame to keep the DAC fed.
+    # A test frame gives us the point count; the DAC consumes at scan rate.
+    test_frame = build_cube_frame(0, 0, 0, r, g, b)
+    pts_per_frame = len(test_frame)
+    update_hz = 30  # how often we recalculate the rotation angle
+    repeats = max(1, int(args.scan / (pts_per_frame * update_hz)) + 1)
+    frame_interval = 1.0 / update_hz
+
+    print(f"Sending cube to {args.ip}:{UDP_PORT}")
+    print(f"Scan rate: {args.scan} Hz, rotation: {args.rpm} RPM, color: #{c}")
+    print(f"Points/frame: {pts_per_frame}, repeats: {repeats}, update: {update_hz} Hz")
+    print("Ctrl+C to stop")
+
+    t0 = time.monotonic()
+    try:
+        while True:
+            t = time.monotonic() - t0
+            ax = t * rads_per_sec * 0.7
+            ay = t * rads_per_sec
+            az = t * rads_per_sec * 0.3
+            frame = build_cube_frame(ax, ay, az, r, g, b)
+            packets = pack_frame(frame)
+            for _ in range(repeats):
+                for pkt in packets:
+                    sock.sendto(pkt, target)
+            time.sleep(frame_interval)
+    except KeyboardInterrupt:
+        sock.sendto(struct.pack('>B', IW_TYPE_0), target)
+        print("\nStopped")
+
+
+if __name__ == "__main__":
+    main()

--- a/firmware/Python/iwp-star.py
+++ b/firmware/Python/iwp-star.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+
+# Rotating 5-point star pattern via IWP
+# Usage: python iwp-star.py --ip 192.168.0.209
+
+import argparse
+import math
+import socket
+import struct
+import time
+
+IW_TYPE_0 = 0x00
+IW_TYPE_1 = 0x01
+IW_TYPE_3 = 0x03
+
+UDP_PORT = 7200
+
+CENTER = 0x8000
+RADIUS_OUTER = 0x6000
+RADIUS_INNER = 0x2600  # ~0.382 * outer for a regular star
+POINTS_PER_SEGMENT = 8  # interpolated points per line segment
+BLANK_DWELL = 3  # dwell points at each blanked move
+
+
+def star_vertices(angle_offset: float):
+    """Generate 10 vertices of a 5-point star (alternating outer/inner)."""
+    verts = []
+    for i in range(10):
+        a = angle_offset + math.pi * 2 * i / 10 - math.pi / 2
+        r = RADIUS_OUTER if i % 2 == 0 else RADIUS_INNER
+        x = CENTER + int(r * math.cos(a))
+        y = CENTER + int(r * math.sin(a))
+        verts.append((x, y))
+    return verts
+
+
+def interpolate(x0, y0, x1, y1, steps):
+    """Linear interpolation between two points."""
+    pts = []
+    for i in range(steps + 1):
+        t = i / steps
+        x = int(x0 + (x1 - x0) * t)
+        y = int(y0 + (y1 - y0) * t)
+        pts.append((x, y))
+    return pts
+
+
+def build_star_frame(angle_offset: float, r: int, g: int, b: int):
+    """Build a complete star frame with interpolation and blanking."""
+    verts = star_vertices(angle_offset)
+    verts.append(verts[0])  # close the shape
+
+    frame = []
+
+    # Dwell at start with blank
+    x0, y0 = verts[0]
+    for _ in range(BLANK_DWELL):
+        frame.append((x0, y0, 0, 0, 0))
+
+    for i in range(len(verts) - 1):
+        x0, y0 = verts[i]
+        x1, y1 = verts[i + 1]
+        seg = interpolate(x0, y0, x1, y1, POINTS_PER_SEGMENT)
+        for sx, sy in seg:
+            frame.append((sx, sy, r, g, b))
+
+    # Dwell at end
+    xn, yn = verts[-1]
+    for _ in range(BLANK_DWELL):
+        frame.append((xn, yn, 0, 0, 0))
+
+    return frame
+
+
+def pack_frame(frame):
+    """Pack frame points into IWP Type 3 packet bytes."""
+    return b''.join(
+        struct.pack('>BHHHHH', IW_TYPE_3, x, y, r, g, b)
+        for x, y, r, g, b in frame
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Rotating star pattern via IWP")
+    ap.add_argument("--ip", required=True, help="Projector IP address")
+    ap.add_argument("--scan", type=int, default=20000, help="Scan rate Hz (default 20000)")
+    ap.add_argument("--rpm", type=float, default=30, help="Rotation speed in RPM (default 30)")
+    ap.add_argument("--color", default="00ffff", help="Hex color (default 00ffff)")
+    args = ap.parse_args()
+
+    # Parse color
+    c = args.color.lstrip('#')
+    r = int(c[0:2], 16) << 8 | int(c[0:2], 16)
+    g = int(c[2:4], 16) << 8 | int(c[2:4], 16)
+    b = int(c[4:6], 16) << 8 | int(c[4:6], 16)
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    target = (args.ip, UDP_PORT)
+
+    # Set scan period
+    scan_period = max(1, int(1_000_000 / args.scan))
+    sock.sendto(struct.pack('>BI', IW_TYPE_1, scan_period), target)
+    time.sleep(0.01)
+
+    rads_per_sec = args.rpm * 2 * math.pi / 60
+    frame_interval = 1.0 / 60  # ~60 updates/sec
+
+    print(f"Sending star to {args.ip}:{UDP_PORT}")
+    print(f"Scan rate: {args.scan} Hz, rotation: {args.rpm} RPM, color: #{c}")
+    print("Ctrl+C to stop")
+
+    t0 = time.monotonic()
+    try:
+        while True:
+            t = time.monotonic() - t0
+            angle = t * rads_per_sec
+            frame = build_star_frame(angle, r, g, b)
+            packet = pack_frame(frame)
+            sock.sendto(packet, target)
+            time.sleep(frame_interval)
+    except KeyboardInterrupt:
+        # Send blank
+        sock.sendto(struct.pack('>B', IW_TYPE_0), target)
+        print("\nStopped")
+
+
+if __name__ == "__main__":
+    main()

--- a/firmware/Python/iwp-text.py
+++ b/firmware/Python/iwp-text.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+
+# Scrolling text via IWP
+# Usage: python iwp-text.py --ip 192.168.0.209 --text "HELLO WORLD"
+
+import argparse
+import math
+import socket
+import struct
+import time
+
+IW_TYPE_0 = 0x00
+IW_TYPE_1 = 0x01
+IW_TYPE_3 = 0x03
+
+UDP_PORT = 7200
+POINT_SIZE = 11
+MAX_PACKET = 1023
+MAX_POINTS_PER_PACKET = MAX_PACKET // POINT_SIZE
+
+# Stroke font on a 5-wide, 7-tall grid.
+# Each character is a list of strokes (polylines).
+# Each stroke is a list of (x, y) tuples. y=0 is top, y=7 is bottom.
+# Between strokes the beam blanks.
+FONT = {
+    'A': [[(0,7),(0,2),(1,0),(2,0),(3,0),(4,2),(4,7)], [(0,4),(4,4)]],
+    'B': [[(0,7),(0,0),(3,0),(4,1),(4,2),(3,3),(0,3)], [(3,3),(4,4),(4,6),(3,7),(0,7)]],
+    'C': [[(4,1),(3,0),(1,0),(0,1),(0,6),(1,7),(3,7),(4,6)]],
+    'D': [[(0,7),(0,0),(3,0),(4,1),(4,6),(3,7),(0,7)]],
+    'E': [[(4,0),(0,0),(0,3),(3,3)], [(0,3),(0,7),(4,7)]],
+    'F': [[(4,0),(0,0),(0,3),(3,3)], [(0,3),(0,7)]],
+    'G': [[(4,1),(3,0),(1,0),(0,1),(0,6),(1,7),(3,7),(4,6),(4,4),(2,4)]],
+    'H': [[(0,0),(0,7)], [(4,0),(4,7)], [(0,4),(4,4)]],
+    'I': [[(1,0),(3,0)], [(2,0),(2,7)], [(1,7),(3,7)]],
+    'J': [[(1,0),(4,0)], [(3,0),(3,6),(2,7),(1,7),(0,6)]],
+    'K': [[(0,0),(0,7)], [(4,0),(0,4),(4,7)]],
+    'L': [[(0,0),(0,7),(4,7)]],
+    'M': [[(0,7),(0,0),(2,3),(4,0),(4,7)]],
+    'N': [[(0,7),(0,0),(4,7),(4,0)]],
+    'O': [[(1,0),(3,0),(4,1),(4,6),(3,7),(1,7),(0,6),(0,1),(1,0)]],
+    'P': [[(0,7),(0,0),(3,0),(4,1),(4,3),(3,4),(0,4)]],
+    'Q': [[(1,0),(3,0),(4,1),(4,6),(3,7),(1,7),(0,6),(0,1),(1,0)], [(3,6),(4,7)]],
+    'R': [[(0,7),(0,0),(3,0),(4,1),(4,3),(3,4),(0,4)], [(2,4),(4,7)]],
+    'S': [[(4,1),(3,0),(1,0),(0,1),(0,2),(1,3),(3,4),(4,5),(4,6),(3,7),(1,7),(0,6)]],
+    'T': [[(0,0),(4,0)], [(2,0),(2,7)]],
+    'U': [[(0,0),(0,6),(1,7),(3,7),(4,6),(4,0)]],
+    'V': [[(0,0),(2,7),(4,0)]],
+    'W': [[(0,0),(1,7),(2,4),(3,7),(4,0)]],
+    'X': [[(0,0),(4,7)], [(4,0),(0,7)]],
+    'Y': [[(0,0),(2,3),(4,0)], [(2,3),(2,7)]],
+    'Z': [[(0,0),(4,0),(0,7),(4,7)]],
+    '0': [[(1,0),(3,0),(4,1),(4,6),(3,7),(1,7),(0,6),(0,1),(1,0)], [(0,6),(4,1)]],
+    '1': [[(1,1),(2,0),(2,7)], [(1,7),(3,7)]],
+    '2': [[(0,1),(1,0),(3,0),(4,1),(4,3),(0,7),(4,7)]],
+    '3': [[(0,1),(1,0),(3,0),(4,1),(4,2),(3,3),(2,3)], [(3,3),(4,4),(4,6),(3,7),(1,7),(0,6)]],
+    '4': [[(0,0),(0,4),(4,4)], [(3,0),(3,7)]],
+    '5': [[(4,0),(0,0),(0,3),(3,3),(4,4),(4,6),(3,7),(1,7),(0,6)]],
+    '6': [[(3,0),(1,0),(0,1),(0,6),(1,7),(3,7),(4,6),(4,4),(3,3),(0,3)]],
+    '7': [[(0,0),(4,0),(2,7)]],
+    '8': [[(1,0),(3,0),(4,1),(4,2),(3,3),(1,3),(0,2),(0,1),(1,0)],
+          [(1,3),(0,4),(0,6),(1,7),(3,7),(4,6),(4,4),(3,3)]],
+    '9': [[(4,4),(4,1),(3,0),(1,0),(0,1),(0,3),(1,4),(4,4),(4,6),(3,7),(1,7)]],
+    ' ': [],
+    '.': [[(2,6),(2,7)]],
+    ',': [[(2,6),(1,7)]],
+    '!': [[(2,0),(2,5)], [(2,7),(2,7)]],
+    '?': [[(0,1),(1,0),(3,0),(4,1),(4,2),(3,3),(2,3),(2,5)], [(2,7),(2,7)]],
+    '-': [[(1,3),(3,3)]],
+    '+': [[(0,3),(4,3)], [(2,1),(2,5)]],
+    ':': [[(2,2),(2,2)], [(2,6),(2,6)]],
+    '/': [[(0,7),(4,0)]],
+    '(': [[(3,0),(1,2),(1,5),(3,7)]],
+    ')': [[(1,0),(3,2),(3,5),(1,7)]],
+    '#': [[(1,0),(1,7)], [(3,0),(3,7)], [(0,2),(4,2)], [(0,5),(4,5)]],
+    '&': [[(4,7),(1,3),(1,1),(2,0),(3,0),(4,1),(3,2),(0,5),(0,6),(1,7),(3,7),(4,5)]],
+    '*': [[(0,1),(4,5)], [(4,1),(0,5)], [(2,0),(2,6)]],
+    "'": [[(2,0),(2,2)]],
+    '"': [[(1,0),(1,2)], [(3,0),(3,2)]],
+}
+
+CHAR_WIDTH = 5
+CHAR_HEIGHT = 7
+CHAR_SPACING = 1.5  # gap between characters in grid units
+BLANK_DWELL = 3
+
+
+def clamp16(v):
+    return max(0, min(0xFFFF, v))
+
+
+def text_to_strokes(text):
+    """Convert text string to a list of strokes in grid coordinates."""
+    text = text.upper()
+    strokes = []
+    x_offset = 0
+
+    for ch in text:
+        glyph = FONT.get(ch, FONT.get('?', []))
+        for stroke in glyph:
+            strokes.append([(x + x_offset, y) for x, y in stroke])
+        x_offset += CHAR_WIDTH + CHAR_SPACING
+
+    total_width = x_offset - CHAR_SPACING if text else 0
+    return strokes, total_width
+
+
+def interpolate_stroke(stroke, pts_per_unit=2):
+    """Interpolate along a stroke polyline."""
+    result = []
+    for i in range(len(stroke) - 1):
+        x0, y0 = stroke[i]
+        x1, y1 = stroke[i + 1]
+        dist = math.hypot(x1 - x0, y1 - y0)
+        steps = max(1, int(dist * pts_per_unit))
+        for j in range(steps + (1 if i == len(stroke) - 2 else 0)):
+            t = j / steps
+            result.append((x0 + (x1 - x0) * t, y0 + (y1 - y0) * t))
+    if len(stroke) == 1:
+        result.append(stroke[0])
+    return result
+
+
+BOX_FRAC = 0.15  # bounding box as fraction of display (calibrated)
+BOX_W = int(0xFFFF * BOX_FRAC * (5 * (CHAR_WIDTH + CHAR_SPACING) - CHAR_SPACING) / CHAR_HEIGHT)
+BOX_H = int(0xFFFF * BOX_FRAC)
+
+
+def build_text_frame(text, x_scroll=0.0, r=0xFFFF, g=0xFFFF, b=0xFFFF,
+                     scale=None, y_center=0x8000):
+    """Build a frame of text, auto-scaled to fit the calibrated bounding box.
+    x_scroll: horizontal offset in grid units (increases to scroll left).
+    """
+    strokes, total_width = text_to_strokes(text)
+    if not strokes:
+        return [], total_width
+
+    # Auto-fit: scale to whichever dimension is tighter
+    if scale is None:
+        scale_w = BOX_W / total_width if total_width > 0 else 1
+        scale_h = BOX_H / CHAR_HEIGHT
+        scale = min(scale_w, scale_h)
+
+    x_origin = 0x8000 - (total_width * scale) / 2
+    y_origin = y_center - (CHAR_HEIGHT * scale) / 2
+
+    frame = []
+    prev_end = None
+
+    for stroke in strokes:
+        pts = interpolate_stroke(stroke)
+        if not pts:
+            continue
+
+        # Transform to display coordinates with scroll offset
+        transformed = []
+        for gx, gy in pts:
+            sx = clamp16(0xFFFF - int(x_origin + (gx - x_scroll) * scale))
+            sy = clamp16(0xFFFF - int(y_origin + gy * scale))
+            transformed.append((sx, sy))
+
+        # Blank move from previous position
+        if prev_end:
+            for _ in range(BLANK_DWELL):
+                frame.append((*prev_end, 0, 0, 0))
+        for _ in range(BLANK_DWELL):
+            frame.append((*transformed[0], 0, 0, 0))
+
+        # Draw stroke
+        for sx, sy in transformed:
+            frame.append((sx, sy, r, g, b))
+
+        prev_end = transformed[-1]
+
+    # Final blank dwell
+    if prev_end:
+        for _ in range(BLANK_DWELL):
+            frame.append((*prev_end, 0, 0, 0))
+
+    return frame, total_width
+
+
+def pack_frame(frame):
+    packets = []
+    for i in range(0, len(frame), MAX_POINTS_PER_PACKET):
+        chunk = frame[i:i + MAX_POINTS_PER_PACKET]
+        packets.append(b''.join(
+            struct.pack('>BHHHHH', IW_TYPE_3, x, y, r, g, b)
+            for x, y, r, g, b in chunk
+        ))
+    return packets
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Scrolling text via IWP")
+    ap.add_argument("--ip", required=True, help="Projector IP address")
+    ap.add_argument("--text", default="HELLO WORLD", help="Text to display")
+    ap.add_argument("--scan", type=int, default=25000, help="Scan rate Hz")
+    ap.add_argument("--color", default="00ffff", help="Hex color")
+    ap.add_argument("--scroll", action="store_true", help="Enable scrolling")
+    ap.add_argument("--speed", type=float, default=5.0, help="Scroll speed (grid units/sec)")
+    args = ap.parse_args()
+
+    c = args.color.lstrip('#')
+    r = int(c[0:2], 16) << 8 | int(c[0:2], 16)
+    g = int(c[2:4], 16) << 8 | int(c[2:4], 16)
+    b = int(c[4:6], 16) << 8 | int(c[4:6], 16)
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    target = (args.ip, UDP_PORT)
+
+    scan_period = max(1, int(1_000_000 / args.scan))
+    sock.sendto(struct.pack('>BI', IW_TYPE_1, scan_period), target)
+    time.sleep(0.01)
+
+    # Calculate repeats
+    test_frame, total_width = build_text_frame(args.text, r=r, g=g, b=b)
+    pts_per_frame = len(test_frame) if test_frame else 100
+    update_hz = 30
+    repeats = max(1, int(args.scan / (pts_per_frame * update_hz)) + 1)
+    frame_interval = 1.0 / update_hz
+
+    mode = "scrolling" if args.scroll else "static"
+    print(f"Sending text to {args.ip}:{UDP_PORT}: \"{args.text}\"")
+    print(f"Scan rate: {args.scan} Hz, color: #{c}, mode: {mode}")
+    print(f"Points/frame: {pts_per_frame}, repeats: {repeats}")
+    print("Ctrl+C to stop")
+
+    t0 = time.monotonic()
+    try:
+        while True:
+            if args.scroll:
+                t = time.monotonic() - t0
+                x_scroll = t * args.speed
+                # Wrap around
+                display_width_grid = 0xFFFF / ((0xFFFF * 0.6) / CHAR_HEIGHT)
+                if x_scroll > total_width + display_width_grid:
+                    t0 = time.monotonic()
+            else:
+                x_scroll = 0.0
+
+            frame, _ = build_text_frame(args.text, x_scroll=x_scroll, r=r, g=g, b=b)
+            if frame:
+                packets = pack_frame(frame)
+                for _ in range(repeats):
+                    for pkt in packets:
+                        sock.sendto(pkt, target)
+            time.sleep(frame_interval)
+    except KeyboardInterrupt:
+        sock.sendto(struct.pack('>B', IW_TYPE_0), target)
+        print("\nStopped")
+
+
+if __name__ == "__main__":
+    main()

--- a/firmware/Python/iwp.md
+++ b/firmware/Python/iwp.md
@@ -1,0 +1,130 @@
+# IWP (ILDA Wave Protocol) - Python Examples
+
+## Protocol
+
+IWP is a simple UDP protocol on port **7200** for streaming laser points to the ILDAWaveX16.
+
+### Message Types
+
+| Type | Bytes | Description |
+|------|-------|-------------|
+| `0x00` | 1 | Turn off / clear buffer |
+| `0x01` | 5 | Set scan period: `>BI` (type + uint32 microseconds) |
+| `0x02` | 8 | Point with 8-bit color: `>BHHBBB` (type + X + Y + R + G + B) |
+| `0x03` | 11 | Point with 16-bit color: `>BHHHHH` (type + X + Y + R + G + B) |
+
+All multi-byte values are **big-endian**. Multiple messages can be packed into a single UDP packet.
+
+### Coordinate System
+
+- X/Y: unsigned 16-bit (`0x0000` to `0xFFFF`), center at `0x8000`
+- Color (Type 2): 8-bit per channel (0-255), mapped internally to 16-bit
+- Color (Type 3): 16-bit per channel (0-65535)
+
+### Scan Period
+
+Set with Type 1. Value is in microseconds. To convert from Hz:
+```python
+scan_period_us = 1_000_000 // scan_rate_hz
+```
+
+## Example Scripts
+
+### iwp-star.py - Rotating 5-Point Star
+
+```
+python iwp-star.py --ip 192.168.0.209
+python iwp-star.py --ip 192.168.0.209 --scan 20000 --rpm 30 --color 00ffff
+```
+
+| Arg | Default | Description |
+|-----|---------|-------------|
+| `--ip` | (required) | Projector IP address |
+| `--scan` | 20000 | Scan rate in Hz |
+| `--rpm` | 30 | Rotation speed |
+| `--color` | 00ffff | Hex RGB color |
+
+### iwp-cube.py - Rotating 3D Wireframe Cube
+
+```
+python iwp-cube.py --ip 192.168.0.209
+python iwp-cube.py --ip 192.168.0.209 --scan 25000 --rpm 20 --color 00ff40
+```
+
+| Arg | Default | Description |
+|-----|---------|-------------|
+| `--ip` | (required) | Projector IP address |
+| `--scan` | 25000 | Scan rate in Hz |
+| `--rpm` | 20 | Rotation speed |
+| `--color` | 00ff40 | Hex RGB color |
+
+Features perspective projection and optimized edge draw order to minimize blanking moves.
+
+### iwp-text.py - Text Display
+
+```
+python iwp-text.py --ip 192.168.0.209 --text "HELLO"
+python iwp-text.py --ip 192.168.0.209 --text "BEN & ELLA" --color ff00ff
+python iwp-text.py --ip 192.168.0.209 --text "HELLO WORLD" --scroll --speed 8
+```
+
+| Arg | Default | Description |
+|-----|---------|-------------|
+| `--ip` | (required) | Projector IP address |
+| `--text` | HELLO WORLD | Text to display |
+| `--scan` | 25000 | Scan rate in Hz |
+| `--color` | 00ffff | Hex RGB color |
+| `--scroll` | off | Enable scrolling mode |
+| `--speed` | 5.0 | Scroll speed (grid units/sec) |
+
+Uses a built-in Hershey-style stroke font (A-Z, 0-9, punctuation). Text is auto-scaled to fit a calibrated bounding box - short strings appear larger, long strings shrink to fit. Coordinates are inverted in X and Y to match the galvo orientation.
+
+### iwp-ilda.py - ILDA File Streamer
+
+```
+python iwp-ilda.py --file animation.ild --ip 192.168.0.209 --scan 1000
+python iwp-ilda.py --file anim1.ild --ip 192.168.0.209 --scan 100000 --fps 0 --repeat 100
+```
+
+### iwp-gen.ipynb - Interactive Pattern Generator
+
+Jupyter notebook with circle, sine wave, and manual point generators.
+
+## Lessons Learned
+
+### Packet size limit
+
+UDP packets must be chunked to **1023 bytes max** (~93 points at 11 bytes each for Type 3). Larger packets are silently dropped over WiFi. The `iwp-ilda.py` reference implementation uses this limit. The star script (~105 points, ~1155 bytes) worked by luck near the edge; the cube (~156 points, ~1716 bytes) was silently dropped until chunked.
+
+### Buffer fill rate
+
+The firmware's ring buffer holds 8192 points. The DAC consumes points at the scan rate (e.g. 25,000 points/sec). If the sender doesn't supply points fast enough, the display will flicker or go blank. Calculate repeats to keep the buffer fed:
+
+```python
+repeats = max(1, scan_rate_hz // (points_per_frame * update_hz) + 1)
+```
+
+### Coordinate clamping
+
+Projected coordinates (especially with perspective projection) can exceed the uint16 range. Always clamp to 0-65535 before packing:
+
+```python
+def clamp16(v):
+    return max(0, min(0xFFFF, v))
+```
+
+### Blanking and dwell
+
+When drawing disconnected line segments, insert **blanked dwell points** (RGB=0) at both the end of the current segment and the start of the next. This gives the galvos time to reposition without drawing stray lines. 3 dwell points works well.
+
+### Display orientation
+
+The galvo stage on this unit has inverted X and Y relative to the IWP coordinate space. The text script compensates with `0xFFFF - coord` on both axes. Other scripts (star, cube) are symmetric so it doesn't matter, but any asymmetric pattern (text, logos) needs the inversion.
+
+### Auto-fit text scaling
+
+The calibrated bounding box for text is 15% of display height. Auto-fit scales to whichever dimension (width or height) is tighter, so short text fills the height and long text shrinks to fit the width. This keeps all text within the safe scan area regardless of length.
+
+### ESP32-S3 boot modes
+
+After flashing via USB, the device may stay in download mode (`boot:0x0`). Press the RST button **without** holding BOOT to enter normal flash boot (`boot:0x8`).


### PR DESCRIPTION
## Summary
- Add three Python IWP pattern generators: rotating star, 3D wireframe cube, and auto-scaling text display
- Add `iwp.md` documenting the IWP protocol, script usage, and practical lessons learned (packet chunking, buffer fill rates, coordinate clamping, galvo orientation)

## New Files
- `firmware/Python/iwp-star.py` - Rotating 5-point star with configurable scan rate, RPM, and color
- `firmware/Python/iwp-cube.py` - Rotating 3D wireframe cube with perspective projection and optimized edge draw order
- `firmware/Python/iwp-text.py` - Stroke font text display with auto-fit scaling and optional scrolling
- `firmware/Python/iwp.md` - Protocol reference and usage guide

## Test plan
- [x] Verified all three scripts drive XY galvos via IWP on ESP32-S3 at 192.168.0.209
- [x] Confirmed packet chunking at 1023 bytes required for reliable WiFi delivery
- [x] Tested text auto-scaling with short ("HELLO") and long ("BEN & ELLA") strings