### PR TITLE
Fix SD card watchdog timeout and filter hidden files

### DIFF
--- a/firmware/ILDAWaveX16/lib/SDCard/SDCard.cpp
+++ b/firmware/ILDAWaveX16/lib/SDCard/SDCard.cpp
@@ -1,4 +1,6 @@
 #include "SDCard.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 SPIClass SDSPI(FSPI);
 
@@ -78,8 +80,14 @@ void SDCard::listFiles(vector<String>& list, const char* path) {
   if (!root) return;
   File file = root.openNextFile();
   while (file) {
-    if (file.isDirectory()) listFiles(list, file.path());
-    else if (strstr(file.path(), ".ild") || strstr(file.path(), ".ILD")) list.push_back(file.path());    
+    if (file.isDirectory()) {
+      listFiles(list, file.path());
+    } else if (strstr(file.path(), ".ild") || strstr(file.path(), ".ILD")) {
+      // Skip any hidden files that start with dot
+      if (file.name()[0] != '.') {
+        list.push_back(file.path());
+      }
+    }
     file.close();
     file = root.openNextFile();
   }
@@ -90,30 +98,55 @@ String listFilesRecursive(const char *dirname, int depth) {
   File dir = SD.open(dirname);
   if (!dir || !dir.isDirectory()) return "";
 
+  int fileCount = 0;
   while (true) {
     File file = dir.openNextFile();
     if (!file) break;
 
     String fullPath = String(dirname);
-    if (!fullPath.endsWith("/")) fullPath += "/";
+    if (!fullPath.endsWith("/") && strlen(dirname) > 1) fullPath += "/";
     fullPath += file.name();
-    
+
     if (file.isDirectory()) {
       rows += listFilesRecursive(fullPath.c_str(), depth + 1);
     } else if (strstr(file.path(), ".ild") || strstr(file.path(), ".ILD")) {
+      // Skip any hidden files that start with dot
+      if (file.name()[0] == '.') {
+        file.close();
+        continue;
+      }
       rows += "<tr data-filename='" + fullPath + "'>";
       rows += "<td>" + fullPath + "</td>";
       rows += "<td>" + String(file.size()) + " bytes</td>";
       rows += "</tr>";
     }
     file.close();
+
+    // Yield control every 3 files to prevent watchdog timeout
+    fileCount++;
+    if (fileCount % 3 == 0) {
+      vTaskDelay(pdMS_TO_TICKS(50));
+    }
   }
   dir.close();
   return rows;
 }
 
+void SDCard::refreshFileCache() {
+  cachedFileRows = listFilesRecursive("/", 0);
+  lastCacheUpdate = millis();
+}
+
 String SDCard::generateFileRows() {
-  return listFilesRecursive("/", 0);
+  unsigned long currentTime = millis();
+
+  // Check if cache is empty or expired
+  if (cachedFileRows.isEmpty() ||
+      (currentTime - lastCacheUpdate) > CACHE_DURATION_MS) {
+    refreshFileCache();
+  }
+
+  return cachedFileRows;
 }
 
 void SDCard::read(const char* path) {

--- a/firmware/ILDAWaveX16/lib/SDCard/SDCard.h
+++ b/firmware/ILDAWaveX16/lib/SDCard/SDCard.h
@@ -21,9 +21,13 @@ class SDCard {
     void list();
     void listFiles(vector<String>& list, const char* path = "/");
     String generateFileRows();
+    void refreshFileCache();
     void read(const char* path);
     File getFile(const char* path);
   private:
+    String cachedFileRows = "";
+    unsigned long lastCacheUpdate = 0;
+    static const unsigned long CACHE_DURATION_MS = 30000; // 30 seconds
 };
 
 #endif /* SDCARD_H */

--- a/firmware/ILDAWaveX16/src/main.cpp
+++ b/firmware/ILDAWaveX16/src/main.cpp
@@ -660,6 +660,7 @@ void setup() {
   esp_wifi_set_ps(WIFI_PS_NONE);
   sd.begin();
   sd.mount();
+  sd.refreshFileCache();
   idn.begin();
   idn.setRendererHandle(&renderer);
   iwp.begin();


### PR DESCRIPTION
With all the new changes I forgot to actually test the SD card and turns out using it crashed the device. These are the fixes.

- Add file listing cache to prevent blocking async_tcp task
- Implement 30-second cache duration with refresh on startup
- Filter dot files (.DS_Store, ._* files) from listings
- Increase task yield frequency to prevent watchdog timeouts

🤖 Generated with [Claude Code](https://claude.ai/code)